### PR TITLE
PP-15698: add platform-bom and bump pay-java-commons to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest.version>3.0</hamcrest.version>
         <jmh.version>1.37</jmh.version>
-        <pay-java-commons.version>1.0.20260812081959</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20260825154634</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <surefire.version>3.5.6</surefire.version>
         <pact.version>4.7.5</pact.version>
@@ -24,6 +24,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>uk.gov.service.payments</groupId>
+                <artifactId>platform-bom</artifactId>
+                <version>${pay-java-commons.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>


### PR DESCRIPTION
Add the new GOV.UK Pay platform BOM to temporarily override patch versions Dropwizard-managed dependencies. Bump pay-java-commons to version that includes the BOM.